### PR TITLE
deprecate rotateEncryptionKeys method #1108

### DIFF
--- a/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/plugin-keychain-azure-kv.ts
+++ b/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/plugin-keychain-azure-kv.ts
@@ -180,10 +180,6 @@ export class PluginKeychainAzureKv
     return `@hyperledger/cactus-plugin-keychain-vault`;
   }
 
-  async rotateEncryptionKeys(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public getEncryptionAlgorithm(): string {
     return (null as unknown) as string;
   }


### PR DESCRIPTION
refactor(keychain): deprecate rotateEncryptionKeys method #1108

used:
`grep -r rotateEncryptionKeys *`

Found 8 locations of the method:
This pull request removes the method from 1/8 locations